### PR TITLE
use several advertisement keys like https://github.com/dakhnod/FakeTag

### DIFF
--- a/components/openhaystack/__init__.py
+++ b/components/openhaystack/__init__.py
@@ -7,22 +7,26 @@ from esphome.components.esp32 import add_idf_sdkconfig_option
 
 DEPENDENCIES = ["esp32"]
 CONFLICTS_WITH = ["esp32_ble_tracker", "esp32_ble_beacon"]
+CONF_KEYS = 'keys'
+CONF_INTERVAL = 'key_switch_interval'
 
 openhaystack_ns = cg.esphome_ns.namespace("openhaystack")
 OpenHaystack = openhaystack_ns.class_("OpenHaystack", cg.Component)
 
 
-def _validate_key(value):
-    try:
-        key = base64.b64decode(value[CONF_KEY])
-        if len(key) != 28:
+def _validate_keys(value):
+    keys = value[CONF_KEYS]
+    for k in keys:
+        try:
+            key = base64.b64decode(k)
+            if len(key) != 28:
+                raise cv.Invalid(
+                    k+" invalid key size. Make sure you're using the base64 advertisement key."
+                )
+        except base64.binascii.Error as base64_error:
             raise cv.Invalid(
-                "Invalid key size. Make sure you're using the base64 advertisement key."
-            )
-    except base64.binascii.Error as base64_error:
-        raise cv.Invalid(
-            "Invalid key. Make sure you're using the base64 advertisement key."
-        ) from base64_error
+                k+" invalid key. Make sure you're using the base64 advertisement key."
+            ) from base64_error
 
     return value
 
@@ -31,21 +35,24 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(OpenHaystack),
-            cv.Required(CONF_KEY): cv.string,
+            cv.Required(CONF_KEYS): cv.ensure_list(cv.string),
+            cv.Optional(CONF_INTERVAL, default=3600): cv.int_range(min=10),
         }
     ).extend(cv.COMPONENT_SCHEMA),
-    _validate_key,
+    _validate_keys,
 )
 
 
 async def to_code(config):
-    encoded_adv_pub_key = config[CONF_KEY]
-    adv_pub_key = base64.b64decode(encoded_adv_pub_key).hex()
-    adv_pub_key_arr = [
-        int(adv_pub_key[i : i + 2], 16) for i in range(0, len(adv_pub_key), 2)
-    ]
-    var = cg.new_Pvariable(config[CONF_ID], adv_pub_key_arr)
+    var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-
+    for encoded_adv_pub_key in config[CONF_KEYS]:
+        adv_pub_key = base64.b64decode(encoded_adv_pub_key).hex()
+        adv_pub_key_arr = [
+            int(adv_pub_key[i : i + 2], 16) for i in range(0, len(adv_pub_key), 2)
+        ]
+        cg.add(var.add_adv_key(adv_pub_key_arr))
+    if CONF_INTERVAL in config:
+        cg.add(var.set_switch_key_interval(config[CONF_INTERVAL]))
     if CORE.using_esp_idf:
         add_idf_sdkconfig_option("CONFIG_BT_ENABLED", True)

--- a/components/openhaystack/__init__.py
+++ b/components/openhaystack/__init__.py
@@ -9,6 +9,7 @@ DEPENDENCIES = ["esp32"]
 CONFLICTS_WITH = ["esp32_ble_tracker", "esp32_ble_beacon"]
 CONF_KEYS = 'keys'
 CONF_INTERVAL = 'key_switch_interval'
+CONF_SAVE = 'save_key_index_to_flash'
 
 openhaystack_ns = cg.esphome_ns.namespace("openhaystack")
 OpenHaystack = openhaystack_ns.class_("OpenHaystack", cg.Component)
@@ -37,6 +38,7 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(OpenHaystack),
             cv.Required(CONF_KEYS): cv.ensure_list(cv.string),
             cv.Optional(CONF_INTERVAL, default=3600): cv.int_range(min=10),
+            cv.Optional(CONF_SAVE, default=False): cv.boolean,
         }
     ).extend(cv.COMPONENT_SCHEMA),
     _validate_keys,
@@ -54,5 +56,7 @@ async def to_code(config):
         cg.add(var.add_adv_key(adv_pub_key_arr))
     if CONF_INTERVAL in config:
         cg.add(var.set_switch_key_interval(config[CONF_INTERVAL]))
+    if CONF_SAVE in config:
+        cg.add(var.set_save_key_index(config[CONF_SAVE]))
     if CORE.using_esp_idf:
         add_idf_sdkconfig_option("CONFIG_BT_ENABLED", True)

--- a/components/openhaystack/openhaystack.cpp
+++ b/components/openhaystack/openhaystack.cpp
@@ -71,9 +71,7 @@ void OpenHaystack::ble_core_task(void *params) {
   while (true) {
     delay(1000);  // NOLINT
     if (global_openhaystack->advertising_keys.size()>1) {
-      if (seconds>0) {
-        seconds--;
-      } else {
+      if (--seconds<=0) {
         seconds = global_openhaystack->interval_;
         global_openhaystack->current_key++;
         if (global_openhaystack->current_key>=global_openhaystack->advertising_keys.size()) global_openhaystack->current_key=0;

--- a/components/openhaystack/openhaystack.cpp
+++ b/components/openhaystack/openhaystack.cpp
@@ -75,12 +75,24 @@ void OpenHaystack::setup() {
 float OpenHaystack::get_setup_priority() const { return setup_priority::BLUETOOTH; }
 void OpenHaystack::ble_core_task(void *params) {
   int seconds = global_openhaystack->interval_;
+  int d = 0,h = 0, m = 0, s = 0;
 
   ble_setup();
   select_key();
 
   while (true) {
     delay(1000);  // NOLINT
+    if (++s>59) {
+      s=0;
+      if (++m>59) {
+        m=0;
+        if (++h>23) {
+          h=0;
+          d++;
+        }
+      }
+      ESP_LOGD(TAG,"uptime %d days %d hours %d minutes", d, h, m);
+    }
     if (global_openhaystack->advertising_keys.size()>1) {
       if (--seconds<=0) {
         seconds = global_openhaystack->interval_;

--- a/components/openhaystack/openhaystack.h
+++ b/components/openhaystack/openhaystack.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/preferences.h"
 
 #ifdef USE_ESP32
 
@@ -15,6 +16,7 @@ class OpenHaystack : public Component {
   explicit OpenHaystack() { advertising_keys.reserve(100); }
   void add_adv_key(const std::array<uint8_t, 28> &advertising_key) { advertising_keys.push_back(advertising_key); }
   void set_switch_key_interval(int interval) { interval_ = interval; }
+  void set_save_key_index(bool value) { save_key_index_ = value; }
   void setup() override;
   void dump_config() override;
   float get_setup_priority() const override;
@@ -27,9 +29,12 @@ class OpenHaystack : public Component {
   static void set_payload_from_key(uint8_t *payload, uint8_t *public_key);
   static void ble_setup();
 
+  ESPPreferenceObject curr_key_saver;
+
   std::vector<std::array<uint8_t, 28>> advertising_keys;
   int current_key;
   int interval_=3600;
+  bool save_key_index_ = false;
   esp_bd_addr_t random_address_ = {0xFF, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
   uint8_t adv_data_[31] = {
     0x1e, /* Length (30) */

--- a/components/openhaystack/openhaystack.h
+++ b/components/openhaystack/openhaystack.h
@@ -13,27 +13,30 @@ namespace openhaystack {
 
 class OpenHaystack : public Component {
  public:
-  explicit OpenHaystack() { advertising_keys.reserve(100); }
-  void add_adv_key(const std::array<uint8_t, 28> &advertising_key) { advertising_keys.push_back(advertising_key); }
-  void set_switch_key_interval(int interval) { interval_ = interval; }
-  void set_save_key_index(bool value) { save_key_index_ = value; }
+  explicit OpenHaystack() { this->advertising_keys_.reserve(100); }
+  void add_adv_key(const std::array<uint8_t, 28> &advertising_key) { this->advertising_keys_.push_back(advertising_key); }
+  void set_switch_key_interval(int interval) { this->interval_ = interval; }
+  void set_save_key_index(bool value) { this->save_key_index_ = value; }
   void setup() override;
+  void loop() override;
   void dump_config() override;
   float get_setup_priority() const override;
 
  protected:
   static void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param);
-  static void ble_core_task(void *params);
-  static void select_key();
+  void select_key();
   static void set_addr_from_key(esp_bd_addr_t addr, uint8_t *public_key);
   static void set_payload_from_key(uint8_t *payload, uint8_t *public_key);
   static void ble_setup();
 
-  ESPPreferenceObject curr_key_saver;
+  ESPPreferenceObject curr_key_saver_;
 
-  std::vector<std::array<uint8_t, 28>> advertising_keys;
-  int current_key;
+  std::vector<std::array<uint8_t, 28>> advertising_keys_;
+  int current_key_;
   int interval_=3600;
+  uint32_t lastmillis_;
+  int s_=0;
+  int seconds_;
   bool save_key_index_ = false;
   esp_bd_addr_t random_address_ = {0xFF, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
   uint8_t adv_data_[31] = {
@@ -49,9 +52,6 @@ class OpenHaystack : public Component {
     0x00, /* Hint (0x00) */
   };
 };
-
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-extern OpenHaystack *global_openhaystack;
 
 }  // namespace openhaystack
 }  // namespace esphome

--- a/components/openhaystack/openhaystack.h
+++ b/components/openhaystack/openhaystack.h
@@ -5,14 +5,16 @@
 #ifdef USE_ESP32
 
 #include <esp_gap_ble_api.h>
+#include <vector>
 
 namespace esphome {
 namespace openhaystack {
 
 class OpenHaystack : public Component {
  public:
-  explicit OpenHaystack(const std::array<uint8_t, 28> &advertising_key) : advertising_key_(advertising_key) {}
-
+  explicit OpenHaystack() { advertising_keys.reserve(100); }
+  void add_adv_key(const std::array<uint8_t, 28> &advertising_key) { advertising_keys.push_back(advertising_key); }
+  void set_switch_key_interval(int interval) { interval_ = interval; }
   void setup() override;
   void dump_config() override;
   float get_setup_priority() const override;
@@ -20,11 +22,14 @@ class OpenHaystack : public Component {
  protected:
   static void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param);
   static void ble_core_task(void *params);
+  static void select_key();
   static void set_addr_from_key(esp_bd_addr_t addr, uint8_t *public_key);
   static void set_payload_from_key(uint8_t *payload, uint8_t *public_key);
   static void ble_setup();
 
-  std::array<uint8_t, 28> advertising_key_;
+  std::vector<std::array<uint8_t, 28>> advertising_keys;
+  int current_key;
+  int interval_=3600;
   esp_bd_addr_t random_address_ = {0xFF, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
   uint8_t adv_data_[31] = {
     0x1e, /* Length (30) */


### PR DESCRIPTION
I modified the component so that it rotates among several keys (I wouldn't want the eventual thief to be alerted there is a tag tracking him).
The configuration parameter **key** is now **keys** and it's a list (I tested with 100 keys). You can specify just one key and it will work like before.
There's a new configuration parameter **key_switch_interval** to specify the interval in seconds when the next key has to be used (by default 3600 = 1 hour).
Since it's the first time I touch esphome and the esp32 and I don't like C++ I'm not sure if what I did is 100% right.
I performed two tests:

1. 100 keys with an interval of 10 seconds, checking with nrf connect on my (android) phone.
2. 100 keys with an interval of 3 minutes and checking apple servers with https://github.com/biemster/FindMy

In test 1 I missed a handful of keys (I don't know if it's because they weren't sent or my phone was too slow to scan.
In test 2 I only saw 59 keys out of 100, I don't know which apple device is picking my tag so I cannot say if this test is failing or it's OK. I'll leave it running with a 10 minutes interval and I'll check later if it picked up more keys.